### PR TITLE
Research godot ai agent integration roadmap

### DIFF
--- a/modules/ai_agent/SCsub
+++ b/modules/ai_agent/SCsub
@@ -1,0 +1,13 @@
+Import('env')
+
+module_env = env.Clone()
+
+sources = [
+    'register_types.cpp',
+    'ai_server.cpp',
+]
+
+module_env.add_source_files(env.modules_sources, sources)
+
+if env.editor_build:
+    module_env.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/ai_agent/ai_server.cpp
+++ b/modules/ai_agent/ai_server.cpp
@@ -1,0 +1,40 @@
+#include "ai_server.h"
+
+#include "core/object/class_db.h"
+
+AIServer *AIServer::singleton = nullptr;
+
+void AIServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("start_session", "config"), &AIServer::start_session);
+	ClassDB::bind_method(D_METHOD("stop_session", "session"), &AIServer::stop_session);
+	ClassDB::bind_method(D_METHOD("ask", "prompt", "options"), &AIServer::ask, DEFVAL(Dictionary()));
+}
+
+AIServer *AIServer::get_singleton() {
+	return singleton;
+}
+
+AIServer::AIServer() {
+	singleton = this;
+}
+
+AIServer::~AIServer() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
+Dictionary AIServer::start_session(const Dictionary &p_config) {
+	Dictionary session;
+	session["id"] = (int64_t)this; // placeholder unique id
+	session["active"] = true;
+	return session;
+}
+
+void AIServer::stop_session(const Dictionary &p_session) {
+	// placeholder
+}
+
+String AIServer::ask(const String &p_prompt, const Dictionary &p_options) {
+	return String("[AIServer stub] ") + p_prompt;
+}

--- a/modules/ai_agent/ai_server.h
+++ b/modules/ai_agent/ai_server.h
@@ -1,0 +1,29 @@
+#ifndef AI_SERVER_H
+#define AI_SERVER_H
+
+#include "core/object/object.h"
+#include "core/object/ref_counted.h"
+#include "core/variant/dictionary.h"
+#include "core/object/class_db.h"
+
+class AIServer : public Object {
+	GDCLASS(AIServer, Object);
+
+private:
+	static AIServer *singleton;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static AIServer *get_singleton();
+
+	AIServer();
+	~AIServer();
+
+	Dictionary start_session(const Dictionary &p_config);
+	void stop_session(const Dictionary &p_session);
+	String ask(const String &p_prompt, const Dictionary &p_options = Dictionary());
+};
+
+#endif // AI_SERVER_H

--- a/modules/ai_agent/config.py
+++ b/modules/ai_agent/config.py
@@ -1,0 +1,6 @@
+def can_build(env, platform):
+    return True
+
+
+def configure(env):
+    pass

--- a/modules/ai_agent/editor/ai_agent_editor_plugin.cpp
+++ b/modules/ai_agent/editor/ai_agent_editor_plugin.cpp
@@ -1,0 +1,12 @@
+#include "ai_agent_editor_plugin.h"
+
+#include "editor/editor_node.h"
+#include "editor/editor_plugins.h"
+
+#ifdef TOOLS_ENABLED
+
+static void _ai_agent_editor_init() {
+	EditorPlugins::add_by_type<AIAgentEditorPlugin>();
+}
+
+#endif

--- a/modules/ai_agent/editor/ai_agent_editor_plugin.h
+++ b/modules/ai_agent/editor/ai_agent_editor_plugin.h
@@ -1,0 +1,41 @@
+#ifndef AI_AGENT_EDITOR_PLUGIN_H
+#define AI_AGENT_EDITOR_PLUGIN_H
+
+#include "editor/plugins/editor_plugin.h"
+#include "scene/gui/label.h"
+
+class AIAgentEditorPlugin : public EditorPlugin {
+	GDCLASS(AIAgentEditorPlugin, EditorPlugin);
+
+	Control *dock = nullptr;
+	Label *label = nullptr;
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	AIAgentEditorPlugin() {}
+	~AIAgentEditorPlugin() {}
+
+	virtual String _get_plugin_name() const override { return "AI Agent"; }
+	virtual bool _has_main_screen() const override { return false; }
+	virtual void _enable_plugin() override {
+		if (!dock) {
+			dock = memnew(Control);
+			label = memnew(Label);
+			label->set_text("AI Agent Dock");
+			dock->add_child(label);
+			add_control_to_dock(DOCK_SLOT_RIGHT_UR, dock);
+		}
+	}
+	virtual void _disable_plugin() override {
+		if (dock) {
+			remove_control_from_docks(dock);
+			dock->queue_free();
+			dock = nullptr;
+			label = nullptr;
+		}
+	}
+};
+
+#endif // AI_AGENT_EDITOR_PLUGIN_H

--- a/modules/ai_agent/register_types.cpp
+++ b/modules/ai_agent/register_types.cpp
@@ -1,0 +1,38 @@
+#include "register_types.h"
+
+#include "core/config/engine.h"
+#include "core/object/class_db.h"
+
+#include "ai_server.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/plugins/editor_plugin.h"
+#include "editor/editor_plugins.h"
+#include "editor/ai_agent_editor_plugin.h"
+#endif
+
+static AIServer *ai_server_singleton = nullptr;
+
+void initialize_ai_agent_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		GDREGISTER_CLASS(AIServer);
+	}
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		ai_server_singleton = memnew(AIServer);
+		Engine::get_singleton()->add_singleton(Engine::Singleton("AIServer", ai_server_singleton));
+	}
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		EditorPlugins::add_by_type<AIAgentEditorPlugin>();
+	}
+#endif
+}
+
+void uninitialize_ai_agent_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		if (ai_server_singleton) {
+			memdelete(ai_server_singleton);
+			ai_server_singleton = nullptr;
+		}
+	}
+}

--- a/modules/ai_agent/register_types.h
+++ b/modules/ai_agent/register_types.h
@@ -1,0 +1,9 @@
+#ifndef AI_AGENT_REGISTER_TYPES_H
+#define AI_AGENT_REGISTER_TYPES_H
+
+#include "modules/register_module_types.h"
+
+void initialize_ai_agent_module(ModuleInitializationLevel p_level);
+void uninitialize_ai_agent_module(ModuleInitializationLevel p_level);
+
+#endif // AI_AGENT_REGISTER_TYPES_H


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
### feat: Add foundational AI Agent module and editor plugin stub

This PR introduces the initial architectural components for integrating a context-aware AI agent workflow into Godot Engine.

**Why this change?**
This is the first step towards enabling advanced AI capabilities within Godot, allowing for:
- **Runtime AI agents:** For in-game AI behaviors, tool-calling, and dynamic content generation.
- **Editor AI assistance:** For code generation, scene manipulation, and context-aware help.

**What does this PR do?**
- **Adds a new `modules/ai_agent`:** This module will house the core AI agent logic.
- **Introduces `AIServer` singleton:** A central manager accessible globally in GDScript, providing stub methods for session management and basic interaction.
- **Integrates with SCons:** Ensures the new module is discoverable and buildable within the Godot compilation system.
- **Adds a minimal editor plugin stub:** Creates an "AI Agent Dock" in the editor, serving as a placeholder for future UI integration.

This PR focuses on establishing the necessary structural foundation for future development of the AI agent system. The current implementation is minimal, primarily for validating the integration points and build process.

---
<a href="https://cursor.com/background-agent?bcId=bc-8354814a-9fb0-46e7-a054-8c7d75293b8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8354814a-9fb0-46e7-a054-8c7d75293b8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

